### PR TITLE
added parser clap with verbosity levels 0, 1, 2

### DIFF
--- a/src/clap.rs
+++ b/src/clap.rs
@@ -1,0 +1,51 @@
+use clap::{arg, command, Args, Parser, Subcommand};
+
+#[derive(Parser)]
+#[derive(Debug)]
+pub struct CommandLines {
+    #[command(subcommand)]
+    pub subcommand: SubCommands,
+    /// Increase logging verbosity
+    #[arg(short('v'), long, action = clap::ArgAction::Count)]
+    pub verbosity: u8,
+    /// Enable debug output, another way to increase logging verbosity
+    #[arg(
+        long = "debug",
+        env = "CRATE_DEBUG",
+        value_name = "boolean",
+        default_value_t = false
+    )]
+    pub debug: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct ServeArgs {
+    /// IP address to listen on
+    #[arg(
+        short('i'),
+        long = "ip",
+        env = "API_IP",
+        value_name = "address",
+        default_value = "0.0.0.0"
+    )]
+    pub listener_ip: String,
+
+    /// TCP port to listen on
+    #[arg(
+        short('p'),
+        long = "port",
+        env = "API_PORT",
+        value_name = "tcp",
+        default_value_t = 8000
+    )]
+    pub listener_port: u16,
+
+    /// Test printing error message
+    #[arg(
+        short('t'),
+        long = "test-error",
+        value_name = "boolean",
+        default_value_t = false
+    )]
+    pub test_err: bool,
+}


### PR DESCRIPTION
Added parser with the rust clap rate for logging utilities

Simple usage
```
$ cargo run // info level verbosity
$ cargo run -- -v 1 // debug level verbosity
$ cargo run -- -v 2 // trace level verbosity
```